### PR TITLE
Updated for abbreviated IPv6 addresses

### DIFF
--- a/IPv4_IPv6_validator.py
+++ b/IPv4_IPv6_validator.py
@@ -1,45 +1,44 @@
-#!/usr/bin/env python
+
+import ipaddress
+
+
 def  check_IP( s):
-    is_ipv4 = True
-    is_ipv6 = True
+   try:
+       
+     ipaddress.ip_address(addr)
+     is_ipv4 = True
+     is_ipv6 = True
     
-    #check if IPv4
-    numbers = s.split(".")
-    if len(numbers) != 4:
+     #check if IPv4
+     numbers = addr.split(".")
+     if len(numbers) != 4:
         is_ipv4 = False
-    if (is_ipv4):
+     if (is_ipv4):
         for x in numbers:
             if not x.isdigit():
                 is_ipv4 = False
             i = int(x)
             if i < 0 or i > 255:
                 is_ipv4 = False
-            
-    #check if IPv6
-    if not is_ipv4:
-        numbers = s.split(":")
-        if len(numbers) != 8:
-            is_ipv6 = False
-        for x in numbers:
-            #check if exadecimal 
-            try:
-                is_hex = int(x, 16)
-            except:
-                is_ipv6 = False
-                break;
-        #if here, every number was hexadecimal
-        
-    if is_ipv4:
-        print "IPv4"
-    elif is_ipv6:
-        print "IPv6"
-    else:
-        print "Neither"
 
-finished = False
-while (not finished):
-    addr = raw_input("Insert address to validate: ")
-    if addr == "end":
-        finished = True
-    else:
-        check_IP(addr)
+     if is_ipv4:
+        print ("The address {0} is IPv4".format(addr))      
+
+     #If not IPv4 then It is IPv6 else throw error.
+     if not is_ipv4:
+         print("The address {0} is IPv6".format(addr))
+         
+        
+   except ValueError as e:
+            print(e)
+
+if __name__ == '__main__':
+
+    
+    while True:
+      addr = input("Insert address to validate: ")
+    
+      check_IP(addr)
+
+
+    


### PR DESCRIPTION
Most IPv6 addresses do not occupy all of their possible 128 bits. This condition results in fields that are padded with zeros or contain only zeros. The IPv6 addressing architecture allows you use the two-colon (::) notation to represent contiguous 16-bit fields of zeros. The (::) can only appear once in an address.

For Example:-
Address 2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b can be abbreviated as 2001:db8:3c4d:15::1a2f:1a2b

First it was not working for abbreviated addresses, Now it is updated to work for abbreviated addresses also.
